### PR TITLE
Allow customization of webhook username

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,47 @@ Default config generated on startup:
 
 ```toml
 # Don't change this
-config_version = "1.3"
+config_version = "1.4"
 
 [discord]
 # Bot token from https://discordapp.com/developers/applications/
 token = "TOKEN"
-# Channel ID to send minecraft chat messages to
+# Channel ID to send Minecraft chat messages to
 channel = "000000000000000000"
 
-# Use a Discord webhook to send messages in a more fancy way (otherwise it will use the bot account)
-# This will show the player's avatar and name as the sender
+# Show messages from bots in Minecraft chat
+show_bot_messages = false
+# Show clickable links for attachments in Minecraft chat
+show_attachments_ingame = true
+
+# Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below
-use_webhooks = false
-# Full webhook URL to send more fancy minecraft chat messages to
+use_webhook = false
+
+[discord.webhook]
+# Full webhook URL to send more fancy Minecraft chat messages to
 webhook_url = ""
 # Full URL of an avatar service to get the player's avatar from
 # Placeholders {uuid} and {username} are available
 avatar_url = "https://crafatar.com/avatars/{uuid}?overlay"
-
-# Show messages from bots in minecraft chat
-show_bot_messages = false
-# Show clickable links for attachments in minecraft chat
-show_attachments_ingame = true
+# The format of the webhook's username
+# Placeholders {username} and {server} are available
+webhook_username = "{username}"
 
 # Minecraft > Discord message formats
 # Uses the same formatting as the Discord client
 [discord.chat]
-# The format set in the following key "discord.chat.message" is ignored when webhooks are used
+# The format set in the following key "discord.chat.message" is ignored when a webhook is used
+# Placeholders {username}, {server}, and {message} are available
 message = "{username}: {message}"
+# Placeholders {username} and {server} are available
 join_message = "**{username} joined the game**"
 leave_message = "**{username} left the game**"
+# Placeholders {username}, {current}, and {previous} are available
 server_switch_message = "**{username} moved to {current} from {previous}**"
+# Placeholders {username} and {death_message} are available
 death_message = "**{username} {death_message}**"
+# Placeholders {username}, {advancement_title}, and {advancement_description} are available
 advancement_message = "**{username} has made the advancement __{advancement_title}__**\n_{advancement_description}_"
 
 [discord.commands.list]
@@ -54,7 +63,7 @@ discord_chunk = "<dark_gray>[<{discord_color}>Discord<dark_gray>]<reset>"
 username_chunk = "<{role_color}><hover:show_text:{username}#{discriminator}>{nickname}</hover><reset>"
 message = "{discord_chunk} {username_chunk}<dark_gray>: <reset>{message} {attachments}"
 attachments = "<dark_gray><click:open_url:{url}>[<{attachment_color}>Attachment<dark_gray>]</click><reset>"
-# colors for the <{discord_color}> and <{attachment_color}> tags
+# Colors for the <{discord_color}> and <{attachment_color}> tags
 discord_color = "#7289da"
 attachment_color = "#4abdff"
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
 
-# Use a Discord webhook to have the bot use the player's username and avatar when sending messages
+# OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below
 use_webhook = false
 

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -15,7 +15,7 @@ public class Config {
     private final Path dataDir;
 
     public static final String CONFIG_MAJOR_VERSION = "1";
-    public static final String CONFIG_MINOR_VERSION = "3";
+    public static final String CONFIG_MINOR_VERSION = "4";
     public static final String CONFIG_VERSION = CONFIG_MAJOR_VERSION + "." + CONFIG_MINOR_VERSION;
 
     private static final String DefaultToken = "TOKEN";
@@ -26,14 +26,15 @@ public class Config {
     public String DISCORD_TOKEN = DefaultToken;
     public String CHANNEL_ID = DefaultChannelId;
 
-    // webhooks
-    public Boolean DISCORD_USE_WEBHOOKS = false;
-    public String DISCORD_WEBHOOK_URL = DefaultWebhookUrl;
-    public String DISCORD_AVATAR_URL = DefaultAvatarUrl;
-
     // toggles
     public Boolean SHOW_BOT_MESSAGES = false;
     public Boolean SHOW_ATTACHMENTS = true;
+
+    // webhooks
+    public Boolean DISCORD_USE_WEBHOOK = false;
+    public String WEBHOOK_URL = DefaultWebhookUrl;
+    public String WEBHOOK_AVATAR_URL = DefaultAvatarUrl;
+    public String WEBHOOK_USERNAME = "{username}";
 
     // discord formats
     public String DISCORD_CHAT_MESSAGE = "{username}: {message}";
@@ -110,12 +111,14 @@ public class Config {
     public void loadConfigs() {
         DISCORD_TOKEN = toml.getString("discord.token", DISCORD_TOKEN);
         CHANNEL_ID = toml.getString("discord.channel", CHANNEL_ID);
-        DISCORD_USE_WEBHOOKS = toml.getBoolean("discord.use_webhooks", DISCORD_USE_WEBHOOKS);
-        DISCORD_WEBHOOK_URL = toml.getString("discord.webhook_url", DISCORD_WEBHOOK_URL);
-        DISCORD_AVATAR_URL = toml.getString("discord.avatar_url", DISCORD_AVATAR_URL);
 
         SHOW_BOT_MESSAGES = toml.getBoolean("discord.show_bot_messages", SHOW_BOT_MESSAGES);
         SHOW_ATTACHMENTS = toml.getBoolean("discord.show_attachments_ingame", SHOW_ATTACHMENTS);
+
+        DISCORD_USE_WEBHOOK = toml.getBoolean("discord.use_webhooks", DISCORD_USE_WEBHOOK);
+        WEBHOOK_URL = toml.getString("discord.webhook.webhook_url", WEBHOOK_URL);
+        WEBHOOK_AVATAR_URL = toml.getString("discord.webhook.avatar_url", WEBHOOK_AVATAR_URL);
+        WEBHOOK_USERNAME = toml.getString("discord.webhook.webhook_username", WEBHOOK_USERNAME);
 
         DISCORD_CHAT_MESSAGE = toml.getString("discord.chat.message", DISCORD_CHAT_MESSAGE);
         JOIN_MESSAGE = toml.getString("discord.chat.join_message", JOIN_MESSAGE);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -115,7 +115,7 @@ public class Config {
         SHOW_BOT_MESSAGES = toml.getBoolean("discord.show_bot_messages", SHOW_BOT_MESSAGES);
         SHOW_ATTACHMENTS = toml.getBoolean("discord.show_attachments_ingame", SHOW_ATTACHMENTS);
 
-        DISCORD_USE_WEBHOOK = toml.getBoolean("discord.use_webhooks", DISCORD_USE_WEBHOOK);
+        DISCORD_USE_WEBHOOK = toml.getBoolean("discord.use_webhook", DISCORD_USE_WEBHOOK);
         WEBHOOK_URL = toml.getString("discord.webhook.webhook_url", WEBHOOK_URL);
         WEBHOOK_AVATAR_URL = toml.getString("discord.webhook.avatar_url", WEBHOOK_AVATAR_URL);
         WEBHOOK_USERNAME = toml.getString("discord.webhook.webhook_username", WEBHOOK_USERNAME);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/MessageListener.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/MessageListener.java
@@ -39,7 +39,7 @@ public class MessageListener extends ListenerAdapter {
         this.logger = logger;
         this.config = config;
 
-        final Matcher matcher = WEBHOOK_ID_REGEX.matcher(config.DISCORD_WEBHOOK_URL);
+        final Matcher matcher = WEBHOOK_ID_REGEX.matcher(config.WEBHOOK_URL);
         this.webhookId = matcher.find()
                 ? matcher.group(1)
                 : null;

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -12,7 +12,7 @@ show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
 
-# Use a Discord webhook to have the bot use the player's username and avatar when sending messages
+# OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below
 use_webhook = false
 

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -1,36 +1,45 @@
 # Don't change this
-config_version = "1.3"
+config_version = "1.4"
 
 [discord]
 # Bot token from https://discordapp.com/developers/applications/
 token = "TOKEN"
-# Channel ID to send minecraft chat messages to
+# Channel ID to send Minecraft chat messages to
 channel = "000000000000000000"
 
-# Use a Discord webhook to send messages in a more fancy way (otherwise it will use the bot account)
-# This will show the player's avatar and name as the sender
+# Show messages from bots in Minecraft chat
+show_bot_messages = false
+# Show clickable links for attachments in Minecraft chat
+show_attachments_ingame = true
+
+# Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below
-use_webhooks = false
-# Full webhook URL to send more fancy minecraft chat messages to
+use_webhook = false
+
+[discord.webhook]
+# Full webhook URL to send more fancy Minecraft chat messages to
 webhook_url = ""
 # Full URL of an avatar service to get the player's avatar from
 # Placeholders {uuid} and {username} are available
 avatar_url = "https://crafatar.com/avatars/{uuid}?overlay"
-
-# Show messages from bots in minecraft chat
-show_bot_messages = false
-# Show clickable links for attachments in minecraft chat
-show_attachments_ingame = true
+# The format of the webhook's username
+# Placeholders {username} and {server} are available
+webhook_username = "{username}"
 
 # Minecraft > Discord message formats
 # Uses the same formatting as the Discord client
 [discord.chat]
-# The format set in the following key "discord.chat.message" is ignored when webhooks are used
+# The format set in the following key "discord.chat.message" is ignored when a webhook is used
+# Placeholders {username}, {server}, and {message} are available
 message = "{username}: {message}"
+# Placeholders {username} and {server} are available
 join_message = "**{username} joined the game**"
 leave_message = "**{username} left the game**"
+# Placeholders {username}, {current}, and {previous} are available
 server_switch_message = "**{username} moved to {current} from {previous}**"
+# Placeholders {username} and {death_message} are available
 death_message = "**{username} {death_message}**"
+# Placeholders {username}, {advancement_title}, and {advancement_description} are available
 advancement_message = "**{username} has made the advancement __{advancement_title}__**\n_{advancement_description}_"
 
 [discord.commands.list]
@@ -47,6 +56,6 @@ discord_chunk = "<dark_gray>[<{discord_color}>Discord<dark_gray>]<reset>"
 username_chunk = "<{role_color}><hover:show_text:{username}#{discriminator}>{nickname}</hover><reset>"
 message = "{discord_chunk} {username_chunk}<dark_gray>: <reset>{message} {attachments}"
 attachments = "<dark_gray><click:open_url:{url}>[<{attachment_color}>Attachment<dark_gray>]</click><reset>"
-# colors for the <{discord_color}> and <{attachment_color}> tags
+# Colors for the <{discord_color}> and <{attachment_color}> tags
 discord_color = "#7289da"
 attachment_color = "#4abdff"


### PR DESCRIPTION
This commit allows the webhook username to be customized via the plugin config. Specifically, it adds a key "`discord.webhook.webhook_username`" to `config.toml` that is interpreted as the format of the webhook's username, replacing the variables `{username}` and `{server}` with the username and current server, respectively, of the player sending a Minecraft chat message.

Example: `[{server}] {username}` = `[vanilla] player1`

I also took the liberty of reformatting the default config file, so feel free to crucify me for that :)
(on that note, it might be a good idea to reformat the config file (even more!) to make it more readable, but I figure I've gone far enough already)

Also, I merged the server connect methods, using `ServerConnectedEvent` rather than `PlayerChooseInitialServerEvent` and `ServerPostConnectEvent` separately. This fixes #11.