### PR TITLE
Make /list command ephemeral

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
@@ -63,6 +63,8 @@ public class ListCommand implements ICommand {
         }
         sb.append("```");
 
-        interaction.reply(sb.toString()).queue();
+        interaction.reply(sb.toString())
+                .setEphemeral(true)
+                .queue();
     }
 }


### PR DESCRIPTION
I suggest making the /list command ephemeral. This is showing the response to the command only to the person that invoked it. I think that would be better to prevent spamming of Discord channels.