### PR TITLE
Show player count as activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ channel = "000000000000000000"
 show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
+# Activity of the bot to show in Discord
+discord_activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ channel = "000000000000000000"
 show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
-# Activity of the bot to show in Discord
+# Show a text as playing activity of the bot
+show_activity = true
+# Activity text of the bot to show in Discord
 activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
 # Activity of the bot to show in Discord
-discord_activity_text = "with {amount} players online"
+activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -29,6 +29,7 @@ public class Config {
     // toggles
     public Boolean SHOW_BOT_MESSAGES = false;
     public Boolean SHOW_ATTACHMENTS = true;
+    public Boolean SHOW_ACTIVITY = true;
 
     // webhooks
     public Boolean DISCORD_USE_WEBHOOK = false;
@@ -115,6 +116,7 @@ public class Config {
 
         SHOW_BOT_MESSAGES = toml.getBoolean("discord.show_bot_messages", SHOW_BOT_MESSAGES);
         SHOW_ATTACHMENTS = toml.getBoolean("discord.show_attachments_ingame", SHOW_ATTACHMENTS);
+        SHOW_ACTIVITY = toml.getBoolean("discord.show_activity", SHOW_ACTIVITY);
 
         DISCORD_USE_WEBHOOK = toml.getBoolean("discord.use_webhook", DISCORD_USE_WEBHOOK);
         WEBHOOK_URL = toml.getString("discord.webhook.webhook_url", WEBHOOK_URL);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -127,7 +127,7 @@ public class Config {
         SERVER_SWITCH_MESSAGE = toml.getString("discord.chat.server_switch_message", SERVER_SWITCH_MESSAGE);
         DEATH_MESSAGE = toml.getString("discord.chat.death_message", DEATH_MESSAGE);
         ADVANCEMENT_MESSAGE = toml.getString("discord.chat.advancement_message", ADVANCEMENT_MESSAGE);
-        DISCORD_ACTIVITY_TEXT = toml.getString("discord.discord_activity_text", DISCORD_ACTIVITY_TEXT);
+        DISCORD_ACTIVITY_TEXT = toml.getString("discord.activity_text", DISCORD_ACTIVITY_TEXT);
 
         DISCORD_LIST_ENABLED = toml.getBoolean("discord.commands.list.enabled", DISCORD_LIST_ENABLED);
         DISCORD_LIST_SERVER_FORMAT = toml.getString("discord.commands.list.server_format", DISCORD_LIST_SERVER_FORMAT);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -43,6 +43,7 @@ public class Config {
     public String SERVER_SWITCH_MESSAGE = "**{username} moved to {current} from {previous}**";
     public String DEATH_MESSAGE = "**{username} {death_message}**";
     public String ADVANCEMENT_MESSAGE = "**{username} has made the advancement __{advancement_title}__**\n_{advancement_description}_";
+    public String DISCORD_ACTIVITY_TEXT = "with {amount} players online";
 
     // discord commands
     public Boolean DISCORD_LIST_ENABLED = true;
@@ -126,6 +127,7 @@ public class Config {
         SERVER_SWITCH_MESSAGE = toml.getString("discord.chat.server_switch_message", SERVER_SWITCH_MESSAGE);
         DEATH_MESSAGE = toml.getString("discord.chat.death_message", DEATH_MESSAGE);
         ADVANCEMENT_MESSAGE = toml.getString("discord.chat.advancement_message", ADVANCEMENT_MESSAGE);
+        DISCORD_ACTIVITY_TEXT = toml.getString("discord.discord_activity_text", DISCORD_ACTIVITY_TEXT);
 
         DISCORD_LIST_ENABLED = toml.getBoolean("discord.commands.list.enabled", DISCORD_LIST_ENABLED);
         DISCORD_LIST_SERVER_FORMAT = toml.getString("discord.commands.list.server_format", DISCORD_LIST_SERVER_FORMAT);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -48,6 +48,8 @@ public class Discord extends ListenerAdapter {
     private final Map<String, ICommand> commands = new HashMap<>();
     private TextChannel activeChannel;
 
+    private int lastPlayerCount = -1;
+
     public Discord(ProxyServer server, Logger logger, Config config) {
         this.server = server;
         this.logger = logger;
@@ -226,10 +228,15 @@ public class Discord extends ListenerAdapter {
     }
 
     public void updateActivityPlayerAmount() {
-        jda.getPresence()
-                .setActivity(Activity.playing(
-                        new StringTemplate(config.DISCORD_ACTIVITY_TEXT)
-                                .add("amount", this.server.getPlayerCount())
-                                .toString()));
+        final int playerCount = this.server.getPlayerCount();
+
+        if (this.lastPlayerCount != playerCount) {
+            jda.getPresence()
+                    .setActivity(Activity.playing(
+                            new StringTemplate(config.DISCORD_ACTIVITY_TEXT)
+                                    .add("amount", playerCount)
+                                    .toString()));
+            this.lastPlayerCount = playerCount;
+        }
     }
 }

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -14,6 +14,7 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
@@ -38,6 +39,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 public class Discord extends ListenerAdapter {
+    private final ProxyServer server;
     private final Logger logger;
     private final Config config;
 
@@ -47,6 +49,7 @@ public class Discord extends ListenerAdapter {
     private TextChannel activeChannel;
 
     public Discord(ProxyServer server, Logger logger, Config config) {
+        this.server = server;
         this.logger = logger;
         this.config = config;
 
@@ -96,6 +99,8 @@ public class Discord extends ListenerAdapter {
         var guild = activeChannel.getGuild();
 
         guild.upsertCommand("list", "list players").queue();
+
+        updateActivityPlayerAmount();
     }
 
     @Subscribe(order = PostOrder.FIRST)
@@ -156,6 +161,8 @@ public class Discord extends ListenerAdapter {
         }
 
         sendMessage(message.toString());
+
+        updateActivityPlayerAmount();
     }
 
     @Subscribe
@@ -172,6 +179,8 @@ public class Discord extends ListenerAdapter {
             .add("server", server);
 
         sendMessage(message.toString());
+
+        updateActivityPlayerAmount();
     }
     public void sendMessage(@Nonnull String message) {
         activeChannel.sendMessage(message).queue();
@@ -214,5 +223,13 @@ public class Discord extends ListenerAdapter {
         }
 
         commands.get(command).handle(event);
+    }
+
+    public void updateActivityPlayerAmount() {
+        jda.getPresence()
+                .setActivity(Activity.playing(
+                        new StringTemplate(config.DISCORD_ACTIVITY_TEXT)
+                                .add("amount", this.server.getPlayerCount())
+                                .toString()));
     }
 }

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -20,15 +20,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.session.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.GatewayIntent;
-import net.dv8tion.jda.api.utils.ChunkingFilter;
-import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import ooo.foooooooooooo.velocitydiscord.Config;
 import ooo.foooooooooooo.velocitydiscord.MessageListener;
-import ooo.foooooooooooo.velocitydiscord.yep.AdvancementMessage;
-import ooo.foooooooooooo.velocitydiscord.yep.DeathMessage;
 import ooo.foooooooooooo.velocitydiscord.discord.commands.ICommand;
 import ooo.foooooooooooo.velocitydiscord.discord.commands.ListCommand;
 import ooo.foooooooooooo.velocitydiscord.util.StringTemplate;
+import ooo.foooooooooooo.velocitydiscord.yep.AdvancementMessage;
+import ooo.foooooooooooo.velocitydiscord.yep.DeathMessage;
 
 import javax.annotation.Nonnull;
 import java.text.MessageFormat;
@@ -226,15 +224,17 @@ public class Discord extends ListenerAdapter {
     }
 
     public void updateActivityPlayerAmount() {
-        final int playerCount = this.server.getPlayerCount();
+        if (config.SHOW_ACTIVITY) {
+            final int playerCount = this.server.getPlayerCount();
 
-        if (this.lastPlayerCount != playerCount) {
-            jda.getPresence()
-                    .setActivity(Activity.playing(
-                            new StringTemplate(config.DISCORD_ACTIVITY_TEXT)
-                                    .add("amount", playerCount)
-                                    .toString()));
-            this.lastPlayerCount = playerCount;
+            if (this.lastPlayerCount != playerCount) {
+                jda.getPresence()
+                        .setActivity(Activity.playing(
+                                new StringTemplate(config.DISCORD_ACTIVITY_TEXT)
+                                        .add("amount", playerCount)
+                                        .toString()));
+                this.lastPlayerCount = playerCount;
+            }
         }
     }
 }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -11,6 +11,8 @@ channel = "000000000000000000"
 show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
+# Activity of the bot to show in Discord
+discord_activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -11,7 +11,9 @@ channel = "000000000000000000"
 show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
-# Activity of the bot to show in Discord
+# Show a text as playing activity of the bot
+show_activity = true
+# Activity text of the bot to show in Discord
 activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -12,7 +12,7 @@ show_bot_messages = false
 # Show clickable links for attachments in Minecraft chat
 show_attachments_ingame = true
 # Activity of the bot to show in Discord
-discord_activity_text = "with {amount} players online"
+activity_text = "with {amount} players online"
 
 # OPTIONAL - Use a Discord webhook to have the bot use the player's username and avatar when sending messages
 # Requires a webhook URL to be set below


### PR DESCRIPTION
#### This PR adds:
Showing the current amount of players connected to the proxy as Discord activity. The text/amount gets updated in method `updateActivityPlayerAmount()` which will be called when the bot is "ready" (initialize) or a player joined or left the game (regular updates). The activity text is configurable in the config.

#### Screenshot:
![activity](https://user-images.githubusercontent.com/45130096/200426676-ad57c405-c4f4-417c-9340-b7b96d6f8b14.png)
("Spielt" is "is playing" - Discord uses localized texts & my Discord client is setup with the German language.)
