### PR TITLE
/list: Detect if backend server is unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ ephemeral = true
 server_format = "[{server_name} {online_players}/{max_players}]"
 player_format = "- {username}"
 no_players = "No players online"
+server_offline = "Server offline"
 codeblock_lang = "asciidoc"
 
 # Discord > Minecraft message formats

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/Config.java
@@ -54,6 +54,7 @@ public class Config {
     public String DISCORD_LIST_SERVER_FORMAT = "[{server_name} {online_players}/{max_players}]";
     public String DISCORD_LIST_PLAYER_FORMAT = "- {username}";
     public String DISCORD_LIST_NO_PLAYERS = "No players online";
+    public String DISCORD_LIST_SERVER_OFFLINE = "Server offline";
     public String DISCORD_LIST_CODEBLOCK_LANG = "asciidoc";
 
     // minecraft formats
@@ -141,6 +142,7 @@ public class Config {
         DISCORD_LIST_SERVER_FORMAT = toml.getString("discord.commands.list.server_format", DISCORD_LIST_SERVER_FORMAT);
         DISCORD_LIST_PLAYER_FORMAT = toml.getString("discord.commands.list.player_format", DISCORD_LIST_PLAYER_FORMAT);
         DISCORD_LIST_NO_PLAYERS = toml.getString("discord.commands.list.no_players", DISCORD_LIST_NO_PLAYERS);
+        DISCORD_LIST_SERVER_OFFLINE = toml.getString("discord.commands.list.server_offline", DISCORD_LIST_SERVER_OFFLINE);
         DISCORD_LIST_CODEBLOCK_LANG = toml.getString("discord.commands.list.codeblock_lang", DISCORD_LIST_CODEBLOCK_LANG);
 
         DISCORD_CHUNK = toml.getString("minecraft.discord_chunk", DISCORD_CHUNK);

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -52,7 +52,7 @@ public class Discord extends ListenerAdapter {
         this.logger = logger;
         this.config = config;
 
-        commands.put("list", new ListCommand(server, config));
+        commands.put("list", new ListCommand(server, logger, config));
 
         var messageListener = new MessageListener(server, logger, config);
 

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
@@ -6,13 +6,16 @@ import ooo.foooooooooooo.velocitydiscord.Config;
 import ooo.foooooooooooo.velocitydiscord.util.StringTemplate;
 
 import java.util.concurrent.ExecutionException;
+import java.util.logging.Logger;
 
 public class ListCommand implements ICommand {
     private final ProxyServer server;
+    private final Logger logger;
     private final Config config;
 
-    public ListCommand(ProxyServer server, Config config) {
+    public ListCommand(ProxyServer server, Logger logger, Config config) {
         this.server = server;
+        this.logger = logger;
         this.config = config;
     }
 
@@ -32,7 +35,9 @@ public class ListCommand implements ICommand {
             try {
                 var b = server.ping().get().asBuilder();
                 maxPlayers = b.getMaximumPlayers();
-            } catch (ExecutionException | InterruptedException e) {
+            } catch (ExecutionException e) {
+                logger.warning("Could not ping server: " + e);
+            } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
 
@@ -45,7 +50,11 @@ public class ListCommand implements ICommand {
                     .toString()
             ).append("\n");
 
-            if (playerCount == 0) {
+            if (maxPlayers == 0) {
+                if (!config.DISCORD_LIST_SERVER_OFFLINE.isEmpty()) {
+                    sb.append(config.DISCORD_LIST_SERVER_OFFLINE).append("\n");
+                }
+            } else if (playerCount == 0) {
                 if (!config.DISCORD_LIST_NO_PLAYERS.isEmpty()) {
                     sb.append(config.DISCORD_LIST_NO_PLAYERS).append("\n");
                 }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -60,6 +60,7 @@ ephemeral = true
 server_format = "[{server_name} {online_players}/{max_players}]"
 player_format = "- {username}"
 no_players = "No players online"
+server_offline = "Server offline"
 codeblock_lang = "asciidoc"
 
 # Discord > Minecraft message formats


### PR DESCRIPTION
When `/list` fails to ping a server (i.e. gets "connection refused"), it throws an exception and never replies to the Discord slash command interaction, leading to the generic "application did not respond" error message appearing in Discord. This PR fixes that.

Note, however, that if Velocity has a server defined in `velocity.toml` that *is* a valid server, but *is not a Minecraft server* - say, an HTTP server - it'll hang on the call to `RegisteredServer#ping` until it times out.

This still throws an ExcecutionException, meaning that the command will eventually consider the server in question "offline" regardless; but, since Discord requires a reply to a slash command interaction [within 3 seconds](https://jda.wiki/using-jda/interactions/#responding-to-slash-commands) of it being issued, Discord will time out the interaction before the plugin can finish compiling its server list response, instead returning the aforementioned "application did not respond" message.

This can be "fixed" by deferring the reply to the interaction (`interaction.deferReply()`), giving up to 15 minutes for the server list to finish compiling. However, the ping timeout is relatively long, and will only get longer as you add more HTTP servers to your Velocity config, so there may be a better way to go about fixing this edge case. (if it's even worth fixing!)

Maybe there's some way to detect when `RegisteredServer#ping` receives an invalid (non-Minecraft server) response? (sounds like something that should be in Velocity itself - well, if it were commonplace for people to put weird backend server entries in their Velocity config, that is)

EDIT: Apparently you can decrease the `ping` timeout in ms in `velocity.toml`. And, there was a PR merged into Velocity just yesterday that addresses an adjacent issue.
https://github.com/PaperMC/Velocity/pull/938
What's the best way to go about this, do you think? Just decrease the `ping` timeout in the call in `ListCommand.class`? Or...?

Fixes #7.