### PR TITLE
Prevent disabled servers being included in the output of /list

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/commands/ListCommand.java
@@ -37,6 +37,11 @@ public class ListCommand implements ICommand {
 
     for (var server : servers) {
       var name = server.getServerInfo().getName();
+
+      if (config.serverDisabled(name)) {
+        continue;
+      }
+
       var players = server.getPlayersConnected();
 
       var playerCount = players.size();


### PR DESCRIPTION
This PR prevents servers specified in the `exclude_servers` array in the plugin's config from being listed in the output of the plugin's `/list` Discord command.

(i tried using `servers.removeAll(server -> config.serverDisabled(server.getServerInfo().getName())`, but got an `UnsupportedOperationException` :( )