### PR TITLE
Fix Discord webhooks from other bots not being mirrored to Minecraft

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/MessageListener.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/MessageListener.java
@@ -68,16 +68,18 @@ public class MessageListener extends ListenerAdapter {
     var message = event.getMessage();
     var guild = event.getGuild();
 
+    var color = Color.white;
+    var nickname = author.getName(); // Nickname defaults to username
+
     var member = guild.getMember(author);
-    if (member == null) {
-      logger.warning("failed to get member: " + author.getId());
-      return;
+    if (member != null) {
+      color = member.getColor();
+      if (color == null) {
+        color = Color.white;
+      }
+      nickname = member.getEffectiveName();
     }
 
-    var color = member.getColor();
-    if (color == null) {
-      color = Color.white;
-    }
     var hex = "#" + Integer.toHexString(color.getRGB()).substring(2);
 
     // parse configured message formats
@@ -87,7 +89,7 @@ public class MessageListener extends ListenerAdapter {
     var username_chunk = new StringTemplate(config.minecraft.USERNAME_CHUNK_FORMAT)
       .add("role_color", hex)
       .add("username", author.getName())
-      .add("nickname", member.getEffectiveName()).toString();
+      .add("nickname", nickname).toString();
 
     var attachment_chunk = config.minecraft.ATTACHMENT_FORMAT;
     var message_chunk = new StringTemplate(config.minecraft.MESSAGE_FORMAT)


### PR DESCRIPTION
Add fallbacks to Discord MessageListener when member is null.
This fixes webhooks not being repeated to Minecraft chat.
This is my first Java project in a while so the code quality might stink, but it's a minor change so I figured I'd go ahead and contribute it. Please let me know if there's anything I can do to improve it.

Closes #42 