### PR TITLE
Add discord username chat completion

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/VelocityListener.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/VelocityListener.java
@@ -80,7 +80,7 @@ public class VelocityListener {
     if (previousServer.isPresent() && !config.serverDisabled(previousName)) {
       discord.onServerSwitch(username, uuid.toString(), prefix, server, previousName);
     } else {
-      discord.onJoin(username, uuid.toString(),prefix, server);
+      discord.onJoin(event.getPlayer(), prefix, server);
     }
   }
 

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -135,9 +135,6 @@ public class Discord extends ListenerAdapter {
     // Load all discord users in the channel and add them to MC client chat suggestions
     var members = channel.getMembers();
     mentionCompletions = members.stream().map((m -> "@"+m.getUser().getName())).toList();
-    for (var mention : mentionCompletions) {
-      System.out.println(mention);
-    }
 
     activeChannel = channel;
 


### PR DESCRIPTION
This PR adds the username's of discord users in the chat channel to the minecraft chat completions. This allows discord mentions to be tab completed in game

An example of this in game: 

![2024-12-23_18 26 11](https://github.com/user-attachments/assets/c7b8d113-e2ef-43f8-971c-539d8a95ad2f)
