### PR TITLE
Add support for Discord role prefixes to in-game messages sent from Discord

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/config/MinecraftMessageConfig.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/config/MinecraftMessageConfig.java
@@ -4,6 +4,7 @@ import com.electronwill.nightconfig.core.Config;
 
 public class MinecraftMessageConfig extends BaseConfig {
   public MinecraftMessageConfig(Config config) {
+    rolePrefixes = new RolePrefixConfig(config);
     loadConfig(config);
   }
 
@@ -14,12 +15,15 @@ public class MinecraftMessageConfig extends BaseConfig {
   // formats
   public String DISCORD_CHUNK_FORMAT = "<dark_gray>[<{discord_color}>Discord<dark_gray>]<reset>";
   public String USERNAME_CHUNK_FORMAT = "<{role_color}><insert:@{username}><hover:show_text:{display_name}>{nickname}</hover></insert><reset>";
-  public String MESSAGE_FORMAT = "{discord_chunk} {username_chunk}<dark_gray>: <reset>{message} {attachments}";
+  public String MESSAGE_FORMAT = "{discord_chunk} {role_prefix} {username_chunk}<dark_gray> <dark_gray>»</dark_gray> <reset><gray>{message}</gray> {attachments}";
   public String ATTACHMENT_FORMAT = "<dark_gray><click:open_url:{url}>[<{attachment_color}>Attachment<dark_gray>]</click><reset>";
 
   // colors
   public String DISCORD_COLOR = "#7289da";
   public String ATTACHMENT_COLOR = "#4abdff";
+
+  // role prefixes
+  public final RolePrefixConfig rolePrefixes;
 
   @Override
   protected void loadConfig(Config config) {
@@ -36,5 +40,8 @@ public class MinecraftMessageConfig extends BaseConfig {
     // colors
     DISCORD_COLOR = get(config, "minecraft.discord_color", DISCORD_COLOR);
     ATTACHMENT_COLOR = get(config, "minecraft.attachment_color", ATTACHMENT_COLOR);
+
+    // Reload role prefixes
+    rolePrefixes.loadConfig(config);
   }
 }

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/config/RolePrefixConfig.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/config/RolePrefixConfig.java
@@ -1,0 +1,31 @@
+package ooo.foooooooooooo.velocitydiscord.config;
+
+import com.electronwill.nightconfig.core.Config;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RolePrefixConfig extends BaseConfig {
+  private final Map<String, String> rolePrefixes = new HashMap<>();
+
+  public RolePrefixConfig(Config config) {
+    loadConfig(config);
+  }
+
+  @Override
+  protected void loadConfig(Config config) {
+    rolePrefixes.clear();
+
+    var prefixConfig = config.get("minecraft.role_prefixes");
+    if (prefixConfig instanceof Config roleConfig) {
+      for (var entry : roleConfig.entrySet()) {
+        if (entry.getValue() instanceof String) {
+          rolePrefixes.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+  }
+
+  public String getPrefixForRole(String roleId) {
+    return rolePrefixes.getOrDefault(roleId, "");
+  }
+}

--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/MessageListener.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/MessageListener.java
@@ -77,6 +77,7 @@ public class MessageListener extends ListenerAdapter {
 
     var color = Color.white;
     var nickname = author.getName(); // Nickname defaults to username
+    var rolePrefix = "";
 
     var member = guild.getMember(author);
     if (member != null) {
@@ -85,6 +86,15 @@ public class MessageListener extends ListenerAdapter {
         color = Color.white;
       }
       nickname = member.getEffectiveName();
+
+      // Get the role prefix
+      var highestRole = member.getRoles().stream()
+        .filter(role -> !config.minecraft.rolePrefixes.getPrefixForRole(role.getId()).isEmpty())
+        .findFirst();
+
+      rolePrefix = highestRole
+        .map(role -> config.minecraft.rolePrefixes.getPrefixForRole(role.getId()))
+        .orElse("");
     }
 
     var hex = "#" + Integer.toHexString(color.getRGB()).substring(2);
@@ -110,6 +120,7 @@ public class MessageListener extends ListenerAdapter {
     var attachment_chunk = config.minecraft.ATTACHMENT_FORMAT;
     var message_chunk = new StringTemplate(config.minecraft.MESSAGE_FORMAT)
       .add("discord_chunk", discord_chunk)
+      .add("role_prefix", rolePrefix)
       .add("username_chunk", username_chunk)
       .add("message", message.getContentDisplay());
 

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -227,7 +227,7 @@ discord_chunk = "<dark_gray>[<{discord_color}>Discord<dark_gray>]<reset>"
 username_chunk = "<{role_color}><insert:@{username}><hover:show_text:{display_name}>{nickname}</hover></insert><reset>"
 
 # Placeholders available: {discord_chunk}, {username_chunk}, {attachments}, {message}
-message = "{discord_chunk} {username_chunk}<dark_gray>: <reset>{message} {attachments}"
+message = "{discord_chunk} {role_prefix} {username_chunk}<dark_gray>: <reset>{message} {attachments}"
 
 # Placeholders available: {url}, {attachment_color}
 attachments = "<dark_gray><click:open_url:{url}>[<{attachment_color}>Attachment<dark_gray>]</click><reset>"
@@ -235,3 +235,11 @@ attachments = "<dark_gray><click:open_url:{url}>[<{attachment_color}>Attachment<
 # Colors for the <{discord_color}> and <{attachment_color}> tags
 discord_color = "#7289da"
 attachment_color = "#4abdff"
+
+# Role prefix configuration
+# Format: role_id = "prefix format using MiniMessage"
+[minecraft.role_prefixes]
+"123456789" = "<dark_gray>[</dark_gray><red><b>OWNER</b></red><dark_gray>]</dark_gray>"
+"987654321" = "<dark_gray>[</dark_gray><blue>ADMIN</blue><dark_gray>]</dark_gray>"
+"456789123" = "<dark_gray>[</dark_gray><green>MOD</green><dark_gray>]</dark_gray>"
+"789123456" = "<dark_gray>[</dark_gray><aqua>HELPER</aqua><dark_gray>]</dark_gray>"


### PR DESCRIPTION
This PR adds support for displaying Discord role-based prefixes in Minecraft chat messages that are sent from Discord. Each role can have a custom prefix configured which will be displayed between the Discord tag and username when a user sends a message from Discord to Minecraft. We made this change for our own server but it has been useful.

Example:
![image](https://github.com/user-attachments/assets/88227379-f739-4cb5-bb59-1d8b302f71c7)

Configuration:
```toml
# Role prefix configuration
# Format: role_id = "prefix format using MiniMessage"
[minecraft.role_prefixes]
"123456789" = "<dark_gray>[</dark_gray><red><b>OWNER</b></red><dark_gray>]</dark_gray>"