### PR TITLE
Fix Server Discord Message Advancement Overrides Not Working

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/yep/YepListener.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/yep/YepListener.java
@@ -21,8 +21,8 @@ public class YepListener {
       .getDiscord()
       .onPlayerAdvancement(event.getUsername(),
         uuid,
-        event.getDisplayName(),
         server,
+        event.getDisplayName(),
         event.getTitle(),
         event.getDescription()
       );


### PR DESCRIPTION
This pull request makes a 1 line fix to `YepListener` `.onPlayerAdvancement()` function call. Previously, server and player display names were swapped in the function call, thus making `Discord.onPlayerAdvancment()` ignore overrides entirely. This pull request fixes that and swaps the arguments in the `YepListener` function call.