### PR TITLE
Delete slash commands from guild if commands are disabled

### DIFF
--- a/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
+++ b/src/main/java/ooo/foooooooooooo/velocitydiscord/discord/Discord.java
@@ -149,12 +149,13 @@ public class Discord extends ListenerAdapter {
       );
     }
 
+    var guild = this.mainChannel.getGuild();
     if (!this.commands.isEmpty()) {
-      var guild = this.mainChannel.getGuild();
-
       for (var entry : this.commands.entrySet()) {
         guild.upsertCommand(entry.getKey(), entry.getValue().description()).queue();
       }
+    } else {
+      guild.updateCommands().queue();
     }
   }
 


### PR DESCRIPTION
Delete slash commands from guild if discord.commands.list.enabled in the configuration file is set to false.